### PR TITLE
Fix: change READ_VALUE ignored number of char to 20000

### DIFF
--- a/src/gfun.h
+++ b/src/gfun.h
@@ -41,7 +41,7 @@ template <class T>
 static void READ_VALUE(ifstream &ifs, T &v)
 {
     ifs >> v;
-    ifs.ignore(150, '\n');
+    ifs.ignore(20000, '\n');
     return;
 }
 


### PR DESCRIPTION
The READ_VALUE ignoring number of characters is currently only 150, sometimes causing trouble. Change it to a large number.